### PR TITLE
Fix trailing numbers/period at the end of words which create a faulty search query

### DIFF
--- a/static/global.js
+++ b/static/global.js
@@ -21,7 +21,7 @@ function transliterate(q, update) {
     });
 }
 
-function isKannada(str) {
+function hasKannadaChar(str) {
   return /[\u0C80-\u0CFF]/.test(str);
 }
 
@@ -92,6 +92,8 @@ function isKannada(str) {
 
 
 (function() {
+    const reMatchKannadaWord = new RegExp(/[\u0C80-\u0CFF]+/g);
+    const reMatchNonKannadaBlobs = new RegExp(/[^\u0C80-\u0CFF]+/g);
   // In the results (definitions), if there are Kannada words, hyperlink
   // them to search.
   let defs = document.querySelectorAll(".defs .d");
@@ -101,8 +103,7 @@ function isKannada(str) {
 
   for (let i = 0; i < defs.length; i++) {
     // Go through each definition. Ignore the ASCII ones.
-    console.log(defs[i].innerText, isKannada(defs[i].innerText));
-    if (!isKannada(defs[i].innerText)) {
+    if (!hasKannadaChar(defs[i].innerText)) {
       continue;
     }
 
@@ -112,15 +113,21 @@ function isKannada(str) {
     const s = document.createElement("span");
 
     parts.forEach((v) => {
-      if (!isKannada(v)) {
+      if (!hasKannadaChar(v)) {
         // ASCII word. Append the text as-is.
         s.appendChild(document.createTextNode(v));
       } else {
         // Non-ASCII word. Turn into a link.
         const a = document.createElement("a");
-        a.setAttribute("href", v);
-        a.appendChild(document.createTextNode(v));
+
+        // Some Kannada words have numbers or "." at the end of them
+        // They need to be cleaned, else they'll be part of the query, and fudge results
+        const kannadaWord = v.replace(reMatchNonKannadaBlobs, "");
+        const nonKannadaTrailingSymbol = v.replace(reMatchKannadaWord,"");
+        a.setAttribute("href", kannadaWord);
+        a.appendChild(document.createTextNode(kannadaWord));
         s.appendChild(a);
+        s.appendChild(document.createTextNode(nonKannadaTrailingSymbol));
       }
 
       // Append a space.


### PR DESCRIPTION
Some kannada words in the results definition will have a period sign or number at the end. Currently these become part of the hyperlink as well as the search query, and the results fetched don't match the original word due to these numbers/period sign at the end.

Example:
In the results for [ಲೊಳ್](https://alar.ink/dictionary/kannada/english/%E0%B2%B2%E0%B3%8A%E0%B2%B3%E0%B3%8D), you'll notice some kannada words in results definition have a period or a number at the end. In this case it is "ಲಾಳ1" and "ಲೋಳಿಸರ."

These numbers and period signs creep into the resultant query (as the link contains the same text). The result for "[ಲೋಳಿಸರ.](https://alar.ink/dictionary/kannada/english/%E0%B2%B2%E0%B3%8B%E0%B2%B3%E0%B2%BF%E0%B2%B8%E0%B2%B0.)" are quite different from "[ಲೋಳಿಸರ](https://alar.ink/dictionary/kannada/english/%E0%B2%B2%E0%B3%8B%E0%B2%B3%E0%B2%BF%E0%B2%B8%E0%B2%B0)".

Similarly for "[ಲಾಳ1](https://alar.ink/dictionary/kannada/english/%E0%B2%B2%E0%B2%BE%E0%B2%B31)" and  "[ಲಾಳ](https://alar.ink/dictionary/kannada/english/%E0%B2%B2%E0%B2%BE%E0%B2%B3)"

This is probably an issue in the dataset itself, and that probably needs to be cleaned, but for now this should fix the hack, and separate the trailing number/period from the actual kannada word.

I've tested this within the browser in Edge Dev.
